### PR TITLE
Update permissions

### DIFF
--- a/whispersservices/models.py
+++ b/whispersservices/models.py
@@ -1423,7 +1423,7 @@ class Comment(PermissionsHistoryModel):
 
     # Below the mandatory fields for generic relation
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE, help_text='A foreign key integer value identifying the content type for this comment')
-    object_id = models.PositiveIntegerField(help_text='A positive integer value indentifying an object')
+    object_id = models.PositiveIntegerField(help_text='A positive integer value identifying an object')
     content_object = GenericForeignKey()
 
     @staticmethod

--- a/whispersservices/serializers.py
+++ b/whispersservices/serializers.py
@@ -5030,7 +5030,7 @@ class EventDetailSerializer(serializers.ModelSerializer):
         servreq_ids = list(ServiceRequest.objects.filter(event=obj.id).values_list('id', flat=True))
         servreq_content_type = ContentType.objects.filter(model='servicerequest').first()
         servreq_comments = Comment.objects.filter(object_id__in=servreq_ids, content_type=servreq_content_type)
-        union_comments = event_comments.union(evtloc_comments).union(servreq_comments).order_by('-id')
+        union_comments = event_comments.union(evtloc_comments).union(servreq_comments)#.order_by('-id')
         # return CommentSerializer(union_comments, many=True).data
         combined_comments = []
         for cmt in union_comments:
@@ -5156,7 +5156,7 @@ class EventDetailAdminSerializer(serializers.ModelSerializer):
         servreq_ids = list(ServiceRequest.objects.filter(event=obj.id).values_list('id', flat=True))
         servreq_content_type = ContentType.objects.filter(model='servicerequest').first()
         servreq_comments = Comment.objects.filter(object_id__in=servreq_ids, content_type=servreq_content_type)
-        union_comments = event_comments.union(evtloc_comments).union(servreq_comments).order_by('-id')
+        union_comments = event_comments.union(evtloc_comments).union(servreq_comments)#.order_by('-id')
         # return CommentSerializer(union_comments, many=True).data
         combined_comments = []
         for cmt in union_comments:

--- a/whispersservices/views.py
+++ b/whispersservices/views.py
@@ -469,8 +469,23 @@ class StaffViewSet(HistoryViewSet):
     delete:
     Deletes a staff member.
     """
-    queryset = Staff.objects.all()
     serializer_class = StaffSerializer
+
+    # override the default queryset to allow filtering by URL arguments
+    def get_queryset(self):
+        user = get_request_user(self.request)
+
+        # all requests from anonymous users return nothing
+        if not user or not user.is_authenticated:
+            return Comment.objects.none()
+        # admins and superadmins can see everything
+        elif user.role.is_superadmin or user.role.is_admin:
+            queryset = Comment.objects.all()
+        # otherwise return nothing
+        else:
+            return Comment.objects.none()
+
+        return queryset
 
 
 class LegalStatusViewSet(HistoryViewSet):
@@ -697,7 +712,6 @@ class EventContactViewSet(HistoryViewSet):
     delete:
     Deletes an event contact.
     """
-    queryset = EventContact.objects.all()
     serializer_class = EventContactSerializer
 
     def destroy(self, request, *args, **kwargs):
@@ -707,6 +721,22 @@ class EventContactViewSet(HistoryViewSet):
             message += " unless the event is first re-opened by the event owner or an administrator."
             raise APIException(message)
         return super(EventContactViewSet, self).destroy(request, *args, **kwargs)
+
+    # override the default queryset to allow filtering by URL arguments
+    def get_queryset(self):
+        user = get_request_user(self.request)
+
+        # all requests from anonymous users return nothing
+        if not user or not user.is_authenticated:
+            return EventContact.objects.none()
+        # admins and superadmins can see everything
+        elif user.role.is_superadmin or user.role.is_admin:
+            queryset = EventContact.objects.all()
+        # otherwise return nothing
+        else:
+            return EventContact.objects.none()
+
+        return queryset
 
 
 ######
@@ -791,7 +821,6 @@ class EventLocationContactViewSet(HistoryViewSet):
     delete:
     Deletes an event location contact.
     """
-    queryset = EventLocationContact.objects.all()
     serializer_class = EventLocationContactSerializer
 
     def destroy(self, request, *args, **kwargs):
@@ -801,6 +830,33 @@ class EventLocationContactViewSet(HistoryViewSet):
             message += " unless the event is first re-opened by the event owner or an administrator."
             raise APIException(message)
         return super(EventLocationContactViewSet, self).destroy(request, *args, **kwargs)
+
+    # override the default queryset to allow filtering by URL arguments
+    def get_queryset(self):
+        user = get_request_user(self.request)
+
+        # all requests from anonymous or public users return nothing
+        if not user or not user.is_authenticated or user.role.is_public:
+            return EventLocationContact.objects.none()
+        # admins and superadmins can see everything
+        elif user.role.is_superadmin or user.role.is_admin:
+            queryset = EventLocationContact.objects.all()
+        # partners can see location contacts owned by the user or user's org
+        elif user.role.is_affiliate or user.role.is_partner or user.role.is_partnermanager or user.role.is_partneradmin:
+            # they can also see location contacts for events on which they are collaborators:
+            collab_evt_ids = list(Event.objects.filter(
+                Q(eventwriteusers__user__in=[user.id, ]) | Q(eventreadusers__user__in=[user.id, ])
+            ).values_list('id', flat=True))
+            queryset = EventLocationContact.objects.filter(
+                Q(created_by__exact=user.id) |
+                Q(created_by__organization__exact=user.organization) |
+                Q(event_location__event__in=collab_evt_ids)
+            )
+        # otherwise return nothing
+        else:
+            return EventLocationContact.objects.none()
+
+        return queryset
 
 
 class CountryViewSet(HistoryViewSet):
@@ -1563,8 +1619,40 @@ class CommentViewSet(HistoryViewSet):
     """
     serializer_class = CommentSerializer
 
+    # override the default queryset to allow filtering by URL arguments
     def get_queryset(self):
-        queryset = Comment.objects.all()
+        user = get_request_user(self.request)
+
+        # all requests from anonymous or public users return nothing
+        if not user or not user.is_authenticated or user.role.is_public:
+            return Comment.objects.none()
+        # admins and superadmins can see everything
+        elif user.role.is_superadmin or user.role.is_admin:
+            queryset = Comment.objects.all()
+        # partners can see comments owned by the user or user's org
+        elif user.role.is_affiliate or user.role.is_partner or user.role.is_partnermanager or user.role.is_partneradmin:
+            # they can also see comments for events on which they are collaborators:
+            collab_evt_ids = list(Event.objects.filter(
+                Q(eventwriteusers__user__in=[user.id, ]) | Q(eventreadusers__user__in=[user.id, ])
+            ).values_list('id', flat=True))
+            collab_evtloc_ids = list(EventLocation.objects.filter(
+                event__in=collab_evt_ids).values_list('id', flat=True))
+            collab_evtgrp_ids = list(EventEventGroup.objects.filter(
+                event__in=collab_evt_ids).values_list('id', flat=True))
+            collab_srvreq_ids = list(ServiceRequest.objects.filter(
+                event__in=collab_evt_ids).values_list('id', flat=True))
+            queryset = Comment.objects.filter(
+                Q(created_by__exact=user.id) |
+                Q(created_by__organization__exact=user.organization) |
+                Q(content_type__model='event', object_id__in=collab_evt_ids) |
+                Q(content_type__model='eventlocation', object_id__in=collab_evtloc_ids) |
+                Q(content_type__model='eventeventgroup',object_id__in=collab_evtgrp_ids) |
+                Q(content_type__model='servicerequest', object_id__in=collab_srvreq_ids)
+            )
+        # otherwise return nothing
+        else:
+            return Comment.objects.none()
+
         contains = self.request.query_params.get('contains', None) if self.request else None
         if contains is not None:
             queryset = queryset.filter(comment__contains=contains)
@@ -2197,6 +2285,7 @@ class CSVEventSummaryPublicRenderer(csv_renderers.PaginatedCSVRenderer):
               'counties': 'Counties (or equivalent)', 'species': 'Species', 'eventdiagnoses': 'Event Diagnosis'}
 
 
+# TODO: event collaborators should be able to see private events if those have been shared to collaborators
 class EventSummaryViewSet(ReadOnlyHistoryViewSet):
     """
     list:


### PR DESCRIPTION
1. Comments: Admins see all, Partners see their own/their org's/their collaboration events', anyone else sees an empty list
2. ServiceRequests: Admins see all, Partners see their own/their org's/their collaboration events', anyone else sees an empty list
3. Staff: Admins see all, anyone else sees an empty list
4. EventContacts: Admins see all, anyone else sees an empty list
5. EventLocationContacts: Admins see all, Partners see their own/their org's/their collaboration events', anyone else sees an empty list
6. Roles: anyone can see the whole list (only Admins can edit tho)